### PR TITLE
json_theme: update comment URL and add 'onDrag' option to enum

### DIFF
--- a/schemas/json_theme/show_value_indicator.json
+++ b/schemas/json_theme/show_value_indicator.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://peiffer-innovations.github.io/flutter_json_schemas/schemas/json_theme/show_value_indicator.json",
-  "$comment": "https://api.flutter.dev/flutter/material/ShowValueIndicator-class.html",
+  "$comment": "https://api.flutter.dev/flutter/material/ShowValueIndicator.html",
   "type": "string",
   "title": "ShowValueIndicator",
   "oneOf": [
@@ -10,6 +10,7 @@
       "enum": [
         "always",
         "never",
+        "onDrag",
         "onlyForContinuous",
         "onlyForDiscrete"
       ]


### PR DESCRIPTION
Summary:
- Added `onDrag` option to `ShowValueIndicator` as `always` option will be deprecated after v3.28.0-1.0.pre
- Update flutter dev uri comment on `schemas/json_theme/show_value_indicator.json`